### PR TITLE
Miscellaneous changes to samples

### DIFF
--- a/cblas/Makefile
+++ b/cblas/Makefile
@@ -1,14 +1,14 @@
-target  := cblas.out
-src     := $(wildcard *.cpp)
-obj     := $(patsubst %.cpp, %.o, $(src))
-deps    := $(patsubst %.cpp, %.d, $(src))
-
 mkl   := intel-mkl
 oblas := openblas
 impl  ?= $(oblas)
 ifeq (,$(filter $(impl), $(oblas) $(mkl)))
-$(error unsupported implementation $(impl))
+$(error unsupported implementation $(impl): supported '$(mkl)' '$(oblas)')
 endif
+
+target  ?= cblas-$(impl).out
+src     := $(wildcard *.cpp)
+obj     := $(patsubst %.cpp, %-$(impl).o, $(src))
+deps    := $(patsubst %.cpp, %-$(impl).d, $(src))
 
 incls := ../timeprinter/include ../include
 libs  := ../timeprinter/lib
@@ -73,15 +73,15 @@ else
 cflags += -O3 -DNDEBUG
 endif
 
-.PHONY: default remake clean
+.PHONY: default remake clean purge
 
 default: $(target)
 
 $(target): $(obj)
 	$(cc) $^ $(ldflags) -o $@
 
-%.o: %.cpp %.d
-	$(cc) -MT $@ -MMD -MP -MF $*.d $(cflags) -c -o $@ $<
+%-$(impl).o: %.cpp %-$(impl).d
+	$(cc) -MT $@ -MMD -MP -MF $*-$(impl).d $(cflags) -c -o $@ $<
 
 $(deps):
 
@@ -91,3 +91,6 @@ remake: clean default
 
 clean:
 	rm -rf $(target) $(deps) $(obj)
+
+purge:
+	rm -rf *.o *.out *.d

--- a/cblas/cblas.cpp
+++ b/cblas/cblas.cpp
@@ -15,110 +15,86 @@
 
 namespace
 {
-    auto get_gen(std::mt19937_64& engine, std::uniform_real_distribution<double>& dist)
+    using work_func = void(*)(
+        std::size_t,
+        std::size_t,
+        std::size_t,
+        std::mt19937_64&);
+
+    namespace detail
     {
-        return [&]()
+        template<typename Real, CBLAS_TRANSPOSE Trans, typename Func>
+        void gemm_impl(Func func, std::size_t M, std::size_t N, std::size_t K, std::mt19937_64& engine)
         {
-            return dist(engine);
-        };
+            std::uniform_real_distribution<Real> dist{ 0.0, 1.0 };
+            auto gen = [&]() { return dist(engine); };
+
+            tp::printer tpr;
+            std::vector<Real> a(M * K);
+            std::vector<Real> b(K * N);
+            std::vector<Real> c(M * N);
+            std::generate(a.begin(), a.end(), gen);
+            std::generate(b.begin(), b.end(), gen);
+
+            tpr.sample();
+            func(CblasRowMajor, CblasNoTrans, Trans,
+                M, N, K, 1.0,
+                a.data(), K,
+                b.data(), N,
+                0, c.data(), N
+            );
+        }
     }
 
     __attribute__((noinline)) void dgemm_no_transpose(
         std::size_t M,
         std::size_t N,
         std::size_t K,
-        std::mt19937_64& engine,
-        std::uniform_real_distribution<double>& dist)
+        std::mt19937_64& engine)
     {
-        auto gen = get_gen(engine, dist);
-        std::vector<double> a(M * K);
-        std::vector<double> b(K * N);
-        std::vector<double> c(M * N);
-        std::generate(a.begin(), a.end(), gen);
-        std::generate(b.begin(), b.end(), gen);
-
-        tp::printer tpr;
-        cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-            M, N, K, 1.0,
-            a.data(), K,
-            b.data(), N,
-            0, c.data(), N
-        );
+        return detail::gemm_impl<double, CblasNoTrans>(cblas_dgemm, M, N, K, engine);
     }
 
     __attribute__((noinline)) void dgemm(
         std::size_t M,
         std::size_t N,
         std::size_t K,
-        std::mt19937_64& engine,
-        std::uniform_real_distribution<double>& dist)
+        std::mt19937_64& engine)
     {
-        std::vector<double> a(M * K);
-        std::vector<double> b(K * N);
-        std::vector<double> c(M * N);
-        auto gen = get_gen(engine, dist);
-        std::generate(a.begin(), a.end(), gen);
-        std::generate(b.begin(), b.end(), gen);
-
-        tp::printer tpr;
-        cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
-            M, N, K, 1.0,
-            a.data(), K,
-            b.data(), K,
-            0, c.data(), N
-        );
-    }
-
-    __attribute__((noinline)) void dgemv(
-        std::size_t M,
-        std::size_t N,
-        std::size_t,
-        std::mt19937_64& engine,
-        std::uniform_real_distribution<double>& dist)
-    {
-        std::vector<double> a(M * N);
-        std::vector<double> x(N);
-        std::vector<double> y(M);
-        auto gen = get_gen(engine, dist);
-        std::generate(a.begin(), a.end(), gen);
-
-        tp::printer tpr;
-        cblas_dgemv(CblasRowMajor, CblasNoTrans,
-            M, N, 1.0,
-            a.data(), N,
-            x.data(), 1,
-            0, y.data(), 1);
+        return detail::gemm_impl<double, CblasTrans>(cblas_dgemm, M, N, K, engine);
     }
 
     __attribute__((noinline)) void sgemm(
         std::size_t M,
         std::size_t N,
         std::size_t K,
-        std::mt19937_64& engine,
-        std::uniform_real_distribution<double>& dist)
+        std::mt19937_64& engine)
     {
-        std::vector<float> a(M * K);
-        std::vector<float> b(K * N);
-        std::vector<float> c(M * N);
-        auto gen = get_gen(engine, dist);
-        std::generate(a.begin(), a.end(), gen);
-        std::generate(b.begin(), b.end(), gen);
-
-        tp::printer tpr;
-        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
-            M, N, K, 1.0,
-            a.data(), K,
-            b.data(), K,
-            0, c.data(), N
-        );
+        return detail::gemm_impl<float, CblasTrans>(cblas_sgemm, M, N, K, engine);
     }
 
-    using work_func = void(*)(
+    __attribute__((noinline)) void dgemv(
+        std::size_t M,
+        std::size_t N,
         std::size_t,
-        std::size_t,
-        std::size_t,
-        std::mt19937_64&,
-        std::uniform_real_distribution<double>&);
+        std::mt19937_64& engine)
+    {
+        std::uniform_real_distribution<double> dist{ 0.0, 1.0 };
+        auto gen = [&]() { return dist(engine); };
+
+        tp::printer tpr;
+        std::vector<double> a(M * N);
+        std::vector<double> x(N);
+        std::vector<double> y(M);
+        std::generate(a.begin(), a.end(), gen);
+
+        tpr.sample();
+        cblas_dgemv(CblasRowMajor, CblasNoTrans,
+            M, N, 1.0,
+            a.data(), N,
+            x.data(), 1,
+            0, y.data(), 1);
+    }
 
     class cmdparams
     {
@@ -169,11 +145,9 @@ namespace
             assert(func);
         }
 
-        void do_work(
-            std::mt19937_64& engine,
-            std::uniform_real_distribution<double>& dist)
+        void do_work(std::mt19937_64& engine)
         {
-            func(m, n, k, engine, dist);
+            func(m, n, k, engine);
         }
 
     private:
@@ -189,11 +163,10 @@ int main(int argc, char** argv)
 {
     std::random_device rnd_dev;
     std::mt19937_64 engine{ rnd_dev() };
-    std::uniform_real_distribution dist{ 0.0, 1.0 };
     try
     {
         cmdparams params(argc, argv);
-        params.do_work(engine, dist);
+        params.do_work(engine);
     }
     catch (const std::exception& e)
     {

--- a/lapacke/Makefile
+++ b/lapacke/Makefile
@@ -1,14 +1,14 @@
-target  := lapacke.out
-src     := $(wildcard *.cpp)
-obj     := $(patsubst %.cpp, %.o, $(src))
-deps    := $(patsubst %.cpp, %.d, $(src))
-
 mkl   := intel-mkl
 oblas := openblas
 impl  ?= $(oblas)
 ifeq (,$(filter $(impl), $(oblas) $(mkl)))
-$(error unsupported implementation $(impl))
+$(error unsupported implementation $(impl): supported '$(mkl)' '$(oblas)')
 endif
+
+target  ?= lapacke-$(impl).out
+src     := $(wildcard *.cpp)
+obj     := $(patsubst %.cpp, %-$(impl).o, $(src))
+deps    := $(patsubst %.cpp, %-$(impl).d, $(src))
 
 incls := ../timeprinter/include ../include
 libs  := ../timeprinter/lib
@@ -76,15 +76,15 @@ else
 cflags += -O3 -DNDEBUG
 endif
 
-.PHONY: default remake clean
+.PHONY: default remake clean purge
 
 default: $(target)
 
 $(target): $(obj)
 	$(cc) $^ $(ldflags) -o $@
 
-%.o: %.cpp %.d
-	$(cc) -MT $@ -MMD -MP -MF $*.d $(cflags) -c -o $@ $<
+%-$(impl).o: %.cpp %-$(impl).d
+	$(cc) -MT $@ -MMD -MP -MF $*-$(impl).d $(cflags) -c -o $@ $<
 
 $(deps):
 
@@ -94,3 +94,6 @@ remake: clean default
 
 clean:
 	rm -rf $(target) $(deps) $(obj)
+
+purge:
+	rm -rf *.o *.out *.d


### PR DESCRIPTION
- explicitly sample the `timeprinter` after filling the matrices
- make real distribution local to functions
- change `Makefile` to allow creation of different executables based on the implementation
- implement a template for code reuse purposes