### PR TITLE
LAPACKE sample iterations logic

### DIFF
--- a/lapacke/Makefile
+++ b/lapacke/Makefile
@@ -14,6 +14,8 @@ incls := ../timeprinter/include ../include
 libs  := ../timeprinter/lib
 cpp   :=
 
+USE_ITERATIONS ?=
+DO_COMPUTATION ?=
 NO_LAPACKE_SYMS ?=
 USE_RPATH ?=
 rpath :=
@@ -43,6 +45,13 @@ rpath += -Wl,-rpath,$(OPENBLAS_ROOT)/lib
 endif # USE_RPATH
 
 endif # ($(impl), $(mkl))
+
+ifneq (,$(USE_ITERATIONS))
+cpp += USE_ITERATIONS
+endif # (,$(USE_ITERATIONS))
+ifneq (,$(DO_COMPUTATION))
+cpp += DO_COMPUTATION
+endif # (,$(DO_COMPUTATION))
 
 cc      := g++
 cflags  := -Wall -Wextra -Wunknown-pragmas -pedantic -fPIE -g

--- a/lapacke/lapacke.cpp
+++ b/lapacke/lapacke.cpp
@@ -13,7 +13,12 @@
 #include <random>
 
 #define NO_INLINE __attribute__((noinline))
+
+#if defined(USE_ITERATIONS) && !defined(DO_COMPUTATION)
+#define NO_CLONE __attribute__((noclone,no_icf))
+#else // !defined(USE_ITERATIONS) || defined(DO_COMPUTATION)
 #define NO_CLONE __attribute__((noclone))
+#endif // defined(USE_ITERATIONS) && !defined(DO_COMPUTATION)
 
 namespace
 {

--- a/lapacke/lapacke.cpp
+++ b/lapacke/lapacke.cpp
@@ -167,7 +167,7 @@ namespace
                     for (size_t i = 0; i < g_iters; i++)
                     {
                         std::ignore = std::copy(a, a + a2.size(), std::begin(a2));
-                        std::ignore = std::copy(a, b + b2.size(), std::begin(b2));
+                        std::ignore = std::copy(b, b + b2.size(), std::begin(b2));
                         generic_solver<gesv_caller<Real>>(
                             LAPACK_COL_MAJOR, N, Nrhs, a2.get(), N, ipiv, b2.get(), N);
                     }
@@ -181,7 +181,7 @@ namespace
                     for (size_t i = 0; i < g_iters; i++)
                     {
                         std::ignore = std::copy(a, a + a2.size(), std::begin(a2));
-                        std::ignore = std::copy(a, b + b2.size(), std::begin(b2));
+                        std::ignore = std::copy(b, b + b2.size(), std::begin(b2));
                         query_solver<gels_caller<Real>>(
                             LAPACK_COL_MAJOR, 'N', M, N, Nrhs, a2.get(), M,
                             b2.get(), std::max(N, M));
@@ -227,7 +227,7 @@ namespace
                 template<typename Real>
                 void tptri(Real* a, size_t N)
                 {
-                    util::buffer<Real> a2{ N * N };
+                    util::buffer<Real> a2{ N * (N + 1) / 2 };
                     for (size_t i = 0; i < g_iters; i++)
                     {
                         std::ignore = std::copy(a, a + a2.size(), std::begin(a2));

--- a/lapacke/lapacke.cpp
+++ b/lapacke/lapacke.cpp
@@ -63,7 +63,7 @@ namespace
             struct impl
             {
                 template<typename... Args>
-                int operator()(Args&&...) const { return 0; }
+                constexpr int operator()(Args&&...) const { return 0; }
             };
             using type = Real;
             static constexpr auto value = impl{};


### PR DESCRIPTION
Implement iterations logic in LAPACKE sample to be able to measure the energy consumed when inputs are small.

New Make variables:
- `USE_ITERATIONS`: if empty then compiled executable behaves as if no iteration logic is present.
- `DO_COMPUTATION`: if empty then no LAPACK computation is performed - only input generation and copy; used to measure the input copy before each iteration and then subtract from the results with LAPACK calls (due to the lack of idempotency); applicable only if `USE_ITERATIONS` is not empty.